### PR TITLE
WIP, Rename entry to palette, remove root type

### DIFF
--- a/grammar/oco.jison
+++ b/grammar/oco.jison
@@ -4,9 +4,9 @@
 %%
 
 expressions
-  : EOF { return new yy.Entry('root', [], 'Root', @1) }
-  | entries {  return new yy.Entry('root', $1, 'Root', @1) } // sometimes EOF is already consumed
-  | entries EOF {  return new yy.Entry('root', $1, 'Root', @1) }
+  : EOF { return new yy.Entry('root', [], 'Palette', @1) }
+  | entries {  return new yy.Entry('root', $1, 'Palette', @1) } // sometimes EOF is already consumed
+  | entries EOF {  return new yy.Entry('root', $1, 'Palette', @1) }
   ;
 
 entries

--- a/lib/color_value.js
+++ b/lib/color_value.js
@@ -10,15 +10,15 @@ var ParserError = require('./parser_error');
 
 var ColorValue = function () {
   function ColorValue(name, value) {
-    var identified = arguments.length <= 2 || arguments[2] === undefined ? false : arguments[2];
+    var identifiedValue = arguments.length <= 2 || arguments[2] === undefined ? null : arguments[2];
 
     _classCallCheck(this, ColorValue);
 
     this.name = name;
     this.value = value;
+    this.identifiedValue = identifiedValue;
     this.parent = null;
     this.type = 'ColorValue';
-    this.identified = identified;
   }
 
   _createClass(ColorValue, [{
@@ -26,29 +26,34 @@ var ColorValue = function () {
     value: function hexcolor() {
       var withAlpha = arguments.length <= 0 || arguments[0] === undefined ? false : arguments[0];
 
-      if (this.identified) {
+      if (this.isHexExpressable()) {
         if (withAlpha) {
-          return this.value.toString('hex8').toUpperCase();
+          return this.identifiedValue.toString('hex8').toUpperCase();
         }
-        return this.value.toString('hex6').toUpperCase();
+        return this.identifiedValue.toString('hex6').toUpperCase();
       }
       return null;
     }
   }, {
+    key: 'isHexExpressable',
+    value: function isHexExpressable() {
+      return this.identifiedValue != null;
+    }
+  }, {
     key: 'clone',
     value: function clone() {
-      return new ColorValue(this.name, this.value, this.identified);
+      return new ColorValue(this.name, this.value, this.identifiedValue);
     }
   }], [{
     key: 'fromColorValue',
     value: function fromColorValue(value) {
       var parsed = tinycolor(value);
       if (parsed.isValid()) {
-        return new ColorValue(parsed.getFormat(), parsed, true);
+        return new ColorValue(parsed.getFormat(), value, parsed);
       }
       var space = value.match(/^(\w+)\((.*)\)$/);
       if (space) {
-        return new ColorValue(space[1], space[0], false);
+        return new ColorValue(space[1], space[0], null);
       }
       throw new ParserError('Illegal Color Value: ' + value, {});
     }

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -30,11 +30,8 @@ var Entry = function () {
     this.metadata = {};
     this.children = [];
     this.parent = null;
-    if (arguments.length === 0) {
-      this.type = 'Root';
-    } else {
-      this.type = type || 'Entry';
-    }
+    this.type = type || 'Palette';
+
     this.addChildren(flatten(children || []), false);
     this.validateType();
     this.forEach = Array.prototype.forEach.bind(this.children); // the magic of JavaScript.
@@ -76,7 +73,7 @@ var Entry = function () {
           var pathspec = nameOrIndex.split(".");
           var firstPart = pathspec.shift();
           var existingEntry = this.get(firstPart);
-          if (existingEntry && existingEntry.type === 'Entry') {
+          if (existingEntry && existingEntry.type === 'Palette') {
             existingEntry.set(pathspec.join("."), value);
           } else {
             var newGroup = new Entry(firstPart);
@@ -197,21 +194,21 @@ var Entry = function () {
     value: function validateType() {
       var types = [];
       this.children.forEach(function (child) {
-        var type = child.constructor.name;
+        var type = child.type;
         if (types.indexOf(type) === -1) {
           types.push(type);
         }
       });
       types = types.sort();
       if (types.indexOf('ColorValue') !== -1 && types.indexOf('Color') !== -1) {
-        var message = 'Entry "' + this.name + '" cannot contain colors and color values at the same level (line: ' + (this.position.first_line - 1) + ')';
+        var message = 'Palette "' + this.name + '" cannot contain colors and color values at the same level (line: ' + (this.position.first_line - 1) + ')';
         throw new ParserError(message, { line: this.position.first_line });
       }
-      if (types.indexOf('Entry') !== -1 && types.indexOf('ColorValue') !== -1) {
-        var _message = 'Entry "' + this.name + '" cannot contain palette and color values at the same level (line: ' + (this.position.first_line - 1) + ')';
+      if (types.indexOf('Palette') !== -1 && types.indexOf('ColorValue') !== -1) {
+        var _message = 'Palette "' + this.name + '" cannot contain palette and color values at the same level (line: ' + (this.position.first_line - 1) + ')';
         throw new ParserError(_message, { line: this.position.first_line });
       }
-      if (types.indexOf('ColorValue') !== -1 && this.type === 'Entry') {
+      if (types.indexOf('ColorValue') !== -1 && this.type === 'Palette') {
         this.type = 'Color';
       }
     }

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -66,42 +66,44 @@ var Entry = function () {
     }
   }, {
     key: 'set',
-    value: function set(nameOrIndex, value) {
-      if ('string' === typeof nameOrIndex) {
-        if (nameOrIndex.match(/\./)) {
-          // dotpath, so we need to do a deep lookup
-          var pathspec = nameOrIndex.split(".");
-          var firstPart = pathspec.shift();
-          var existingEntry = this.get(firstPart);
-          if (existingEntry && existingEntry.type === 'Palette') {
-            existingEntry.set(pathspec.join("."), value);
-          } else {
-            var newGroup = new Entry(firstPart);
-            this.set(firstPart, newGroup);
-            newGroup.set(pathspec.join("."), value);
-          }
+    value: function set(path, entry) {
+      var _this = this;
+
+      // if ('string' === typeof nameOrIndex) {
+      if (path.match(/\./)) {
+        // dotpath, so we need to do a deep lookup
+        var pathspec = path.split(".");
+        var firstPart = pathspec.shift();
+        var existingEntry = this.get(firstPart);
+        if (existingEntry && existingEntry.type === 'Palette') {
+          existingEntry.set(pathspec.join("."), entry);
         } else {
-          if (this.get(nameOrIndex)) {
-            this.get(nameOrIndex).parent = null; // nullifying ref
-            this.children.filter(function (child) {
-              return child.name === nameOrIndex;
-            }).forEach(function (child) {
-              child.value = value;
-            });
-            value.name = nameOrIndex;
-          } else {
-            this.children.push(value);
-            value.name = nameOrIndex;
-          }
-          value.parent = this;
+          var newGroup = new Entry(firstPart);
+          this.set(firstPart, newGroup);
+          newGroup.set(pathspec.join("."), entry);
         }
       } else {
-        if (this.children[nameOrIndex]) {
-          this.children[nameOrIndex].parent = null; // nullifying reference
+        entry.name = path;
+        entry.parent = this;
+        if (this.get(path)) {
+          // replace existing entries
+          this.children.filter(function (child) {
+            return child.name === path;
+          }).forEach(function (child) {
+            _this.replaceChild(child, entry);
+          });
+        } else {
+          // add entry
+          this.children.push(entry);
         }
-        this.children[nameOrIndex] = value;
-        value.parent = this;
       }
+      // } else {
+      //   if (this.children[nameOrIndex]) {
+      //     this.children[nameOrIndex].parent = null; // nullifying reference
+      //   }
+      //   this.children[nameOrIndex] = entry;
+      //   entry.parent = this;
+      // }
     }
   }, {
     key: 'path',
@@ -123,7 +125,7 @@ var Entry = function () {
   }, {
     key: 'addMetadata',
     value: function addMetadata(metadata) {
-      var _this = this;
+      var _this2 = this;
 
       Object.keys(metadata).forEach(function (key) {
         if (!key.match(/\//)) {
@@ -139,8 +141,8 @@ var Entry = function () {
             metadata[key] = ColorValue.fromColorValue(metadata[key]);
           }
         }
-        _this.metadata[key] = metadata[key];
-        _this.addParent(_this.metadata[key]);
+        _this2.metadata[key] = metadata[key];
+        _this2.addParent(_this2.metadata[key]);
       });
     }
   }, {
@@ -150,11 +152,18 @@ var Entry = function () {
       this.children = this.children.slice(0, index).concat(this.children.slice(index + 1));
     }
   }, {
+    key: 'replaceChild',
+    value: function replaceChild(child, newEntry) {
+      var currentPosition = this.children.indexOf(child);
+      this.children.splice(currentPosition, 1, newEntry);
+    }
+  }, {
     key: 'addChild',
     value: function addChild(child) {
-      var _this2 = this;
+      var _this3 = this;
 
       var validate = arguments.length <= 1 || arguments[1] === undefined ? true : arguments[1];
+      var position = arguments.length <= 2 || arguments[2] === undefined ? -1 : arguments[2];
 
       if (!child) {
         return;
@@ -168,12 +177,16 @@ var Entry = function () {
         var prefix = child.name + "/";
         Object.keys(child.metadata).forEach(function (key) {
           var combinedKey = (prefix + key).replace(/\/\//g, '/'); // normalize keys
-          _this2.metadata[combinedKey] = child.metadata[key];
-          _this2.addParent(_this2.metadata[combinedKey]);
+          _this3.metadata[combinedKey] = child.metadata[key];
+          _this3.addParent(_this3.metadata[combinedKey]);
         });
       } else {
-        this.children.push(child);
         child.parent = this;
+        if (position === -1) {
+          this.children.push(child);
+        } else {
+          this.children.splice(position, 0, child);
+        }
       }
 
       if (validate) {
@@ -183,10 +196,10 @@ var Entry = function () {
   }, {
     key: 'addChildren',
     value: function addChildren(children) {
-      var _this3 = this;
+      var _this4 = this;
 
       children.forEach(function (child) {
-        _this3.addChild(child, false);
+        _this4.addChild(child, false);
       }, this);
     }
   }, {

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -223,7 +223,7 @@ var Entry = function () {
         filter = true;
       }
       this.children.forEach(function (child) {
-        if (child.type != 'ColorValue' && (!filter || filters.indexOf(child.type) !== -1)) {
+        if (child.type !== 'ColorValue' && (!filter || filters.indexOf(child.type) !== -1)) {
           callback(child);
         }
         if (child.children && child.children.length > 0) {

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -240,7 +240,7 @@ var Entry = function () {
         return null;
       }
       var identifiedColor = this.children.filter(function (child) {
-        return child.identified === true;
+        return child.isHexExpressable();
       })[0];
       if (identifiedColor) {
         return identifiedColor.hexcolor(withAlpha);

--- a/lib/oco-parser.js
+++ b/lib/oco-parser.js
@@ -84,13 +84,13 @@ performAction: function anonymous(yytext, yyleng, yylineno, yy, yystate /* actio
 var $0 = $$.length - 1;
 switch (yystate) {
 case 1:
- return new yy.Entry('root', [], 'Root', _$[$0]) 
+ return new yy.Entry('root', [], 'Palette', _$[$0]) 
 break;
 case 2:
-  return new yy.Entry('root', $$[$0], 'Root', _$[$0]) 
+  return new yy.Entry('root', $$[$0], 'Palette', _$[$0]) 
 break;
 case 3:
-  return new yy.Entry('root', $$[$0-1], 'Root', _$[$0-1]) 
+  return new yy.Entry('root', $$[$0-1], 'Palette', _$[$0-1]) 
 break;
 case 4:
  this.$ = [ $$[$0] ];

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -13,8 +13,8 @@ var Renderer = function () {
   }
 
   _createClass(Renderer, [{
-    key: "renderEntry",
-    value: function renderEntry(entry, indent) {
+    key: "renderPalette",
+    value: function renderPalette(entry, indent) {
       var string = this.renderIndent(indent) + entry.name + ":\n";
       string += this.renderMetadataEntries(entry, indent + 1);
       string += this.renderChildren(entry, indent + 1);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "test": "make test",
     "build": "make build",
-    "test:watch": "watch 'npm test' src",
+    "test:watch": "watch 'npm test' src test",
     "lint": "jshint src/ test/"
   },
   "keywords": [

--- a/src/color_value.js
+++ b/src/color_value.js
@@ -5,35 +5,37 @@ var tinycolor = require('tinycolor2');
 var ParserError = require('./parser_error');
 
 class ColorValue {
-  constructor(name, value, identified = false) {
+  constructor(name, value, identifiedValue = null) {
     this.name = name;
     this.value = value;
+    this.identifiedValue = identifiedValue;
     this.parent = null;
     this.type = 'ColorValue';
-    this.identified = identified;
   }
   hexcolor(withAlpha = false) {
-    if (this.identified) {
+    if (this.isHexExpressable()) {
       if (withAlpha) {
-        return this.value.toString('hex8').toUpperCase();
+        return this.identifiedValue.toString('hex8').toUpperCase();
       }
-      return this.value.toString('hex6').toUpperCase();
+      return this.identifiedValue.toString('hex6').toUpperCase();
     }
     return null;
   }
-
+  isHexExpressable() {
+    return (this.identifiedValue != null);
+  }
   clone() {
-    return new ColorValue(this.name, this.value, this.identified);
+    return new ColorValue(this.name, this.value, this.identifiedValue);
   }
 
   static fromColorValue(value) {
     var parsed = tinycolor(value);
     if (parsed.isValid()) {
-      return new ColorValue(parsed.getFormat(), parsed, true);
+      return new ColorValue(parsed.getFormat(), value, parsed);
     }
     var space = value.match(/^(\w+)\((.*)\)$/);
     if (space) {
-      return new ColorValue(space[1], space[0], false);
+      return new ColorValue(space[1], space[0], null);
     }
     throw(new ParserError('Illegal Color Value: ' + value, {}));
   }

--- a/src/entry.js
+++ b/src/entry.js
@@ -153,7 +153,7 @@ class Entry {
       if(position === -1) {
         this.children.push(child);
       } else {
-        this.children.splice(position, 0, child)
+        this.children.splice(position, 0, child);
       }
     }
 

--- a/src/entry.js
+++ b/src/entry.js
@@ -193,7 +193,7 @@ class Entry {
 
   hexcolor(withAlpha = false) {
     if (this.type !== 'Color') { return null; }
-    var identifiedColor = this.children.filter((child) => child.identified === true)[0];
+    var identifiedColor = this.children.filter((child) => child.isHexExpressable())[0];
     if (identifiedColor) { return identifiedColor.hexcolor(withAlpha); }
     return null;
   }

--- a/src/entry.js
+++ b/src/entry.js
@@ -24,11 +24,8 @@ class Entry {
     this.metadata = {};
     this.children = [];
     this.parent = null;
-    if (arguments.length === 0) {
-      this.type = 'Root';
-    } else {
-      this.type = type || 'Entry';
-    }
+    this.type = type || 'Palette';
+
     this.addChildren(flatten(children || []), false);
     this.validateType();
     this.forEach = Array.prototype.forEach.bind(this.children); // the magic of JavaScript.
@@ -67,7 +64,7 @@ class Entry {
         var pathspec = nameOrIndex.split(".");
         var firstPart = pathspec.shift();
         var existingEntry =  this.get(firstPart);
-        if (existingEntry && existingEntry.type === 'Entry') {
+        if (existingEntry && existingEntry.type === 'Palette') {
           existingEntry.set(pathspec.join("."), value);
         } else {
           var newGroup = new Entry(firstPart);
@@ -163,19 +160,19 @@ class Entry {
   validateType() {
     var types = [];
     this.children.forEach((child) => {
-      let type = child.constructor.name;
+      let type = child.type;
       if (types.indexOf(type) === -1) { types.push(type); }
     });
     types = types.sort();
     if (types.indexOf('ColorValue') !== -1 && types.indexOf('Color') !== -1 ) {
-      let message = `Entry "${this.name}" cannot contain colors and color values at the same level (line: ${this.position.first_line - 1})`;
+      let message = `Palette "${this.name}" cannot contain colors and color values at the same level (line: ${this.position.first_line - 1})`;
       throw(new ParserError(message, {line: this.position.first_line }));
     }
-    if (types.indexOf('Entry') !== -1 && types.indexOf('ColorValue') !== -1) {
-      let message = `Entry "${this.name}" cannot contain palette and color values at the same level (line: ${this.position.first_line - 1})`;
+    if (types.indexOf('Palette') !== -1 && types.indexOf('ColorValue') !== -1) {
+      let message = `Palette "${this.name}" cannot contain palette and color values at the same level (line: ${this.position.first_line - 1})`;
       throw(new ParserError(message, {line: this.position.first_line }));
     }
-    if (types.indexOf('ColorValue') !== -1 && this.type === 'Entry') {
+    if (types.indexOf('ColorValue') !== -1 && this.type === 'Palette') {
       this.type = 'Color';
     }
   }

--- a/src/entry.js
+++ b/src/entry.js
@@ -182,7 +182,7 @@ class Entry {
     if (typeof filters === 'string') { filters = [filters]; }
     if (filters && filters.length > 0) { filter = true; }
     this.children.forEach((child) => {
-      if (child.type != 'ColorValue' && (!filter || filters.indexOf(child.type) !== -1)) {
+      if (child.type !== 'ColorValue' && (!filter || filters.indexOf(child.type) !== -1)) {
         callback(child);
       }
       if (child.children && child.children.length > 0) {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -6,7 +6,7 @@ class Renderer {
     this.root = root;
   }
 
-  renderEntry(entry, indent) {
+  renderPalette(entry, indent) {
     var string = this.renderIndent(indent) + entry.name + ":\n";
     string += this.renderMetadataEntries(entry, indent + 1);
     string += this.renderChildren(entry, indent + 1);

--- a/test/color_value_test.js
+++ b/test/color_value_test.js
@@ -6,13 +6,13 @@ var oco = require('../lib/index.js');
 describe('ColorValue', () => {
   it("should create hex value", () => {
     var colorValue = oco.ColorValue.fromColorValue('#FFA');
-    expect(colorValue.value.toString('hex3')).to.equal('#ffa');
+    expect(colorValue.value).to.equal('#FFA');
     expect(colorValue.name).to.equal('hex');
   });
 
   it("should create rgb value", () => {
     var colorValue = oco.ColorValue.fromColorValue('rgb(134,255,234)');
-    expect(colorValue.value.toString('rgb')).to.equal('rgb(134, 255, 234)');
+    expect(colorValue.value.toString('rgb')).to.equal('rgb(134,255,234)');
     expect(colorValue.name).to.equal('rgb');
   });
 

--- a/test/entry_clone.js
+++ b/test/entry_clone.js
@@ -3,7 +3,6 @@
 var expect = require('chai').expect;
 var oco = require('../lib/index.js');
 var Entry = oco.Entry;
-var ColorValue = oco.ColorValue;
 
 describe('Cloning Entries', () => {
 

--- a/test/entry_test.js
+++ b/test/entry_test.js
@@ -8,7 +8,7 @@ var ColorValue = oco.ColorValue;
 describe('Entry', () => {
   it("should create a root palette when called without arguments", () => {
     var root = new oco.Entry();
-    expect(root.parent).to.be.null;
+    expect(root.parent).to.equal(null);
     expect(root.name).to.equal('Root');
   });
 

--- a/test/entry_test.js
+++ b/test/entry_test.js
@@ -8,7 +8,7 @@ var ColorValue = oco.ColorValue;
 describe('Entry', () => {
   it("should create a root palette when called without arguments", () => {
     var root = new oco.Entry();
-    expect(root.type).to.equal('Root');
+    expect(root.parent).to.be.null;
     expect(root.name).to.equal('Root');
   });
 
@@ -26,7 +26,7 @@ describe('Entry', () => {
 
   it("should throw error when entry and color value are added as children", () => {
     var root = new Entry();
-    root.addChild(new Entry('name', [], 'Entry'));
+    root.addChild(new Entry('name', [], 'Palette'));
     var fun = function() {
       root.addChild(ColorValue.fromColorValue('#FFE'), true);
     };
@@ -36,7 +36,7 @@ describe('Entry', () => {
 
   it("should throw error when entry and color value are added as children", () => {
     var root = new Entry();
-    root.addChild(new Entry('name', [], 'Entry'));
+    root.addChild(new Entry('name', [], 'Palette'));
     var fun = function() {
       root.addChild(ColorValue.fromColorValue('#FFE'), true);
     };

--- a/test/entry_test.js
+++ b/test/entry_test.js
@@ -64,6 +64,6 @@ describe('Entry', () => {
   it("adding metadata via object literals with rgb color", () => {
     var root = new Entry();
     root.addMetadata({'foo/test': 'rgb(123,132,142)'});
-    expect(root.metadata['foo/test'].value.toString('rgb')).to.equal('rgb(123, 132, 142)');
+    expect(root.metadata['foo/test'].value).to.equal('rgb(123,132,142)');
   });
 });

--- a/test/manual_creation_test.js
+++ b/test/manual_creation_test.js
@@ -6,7 +6,7 @@ var oco = require('../lib/index.js');
 describe('Manually creating OCO objects', () => {
   it("should create a root palette", () => {
     var root = new oco.Entry();
-    expect(root.type).to.equal('Root');
+    expect(root.parent).to.be.null;
     expect(root.name).to.equal('Root');
   });
   it("is possible to create more than one entry with sharing one dotpath", () => {

--- a/test/manual_creation_test.js
+++ b/test/manual_creation_test.js
@@ -72,4 +72,24 @@ describe('Deep creating syntax', () => {
     root.set('newentryname', color);
     expect(root.get('newentryname').name).to.equal('newentryname');
   });
+  it("should overwrite existing entry", () => {
+    var root = new oco.Entry();
+    var colorA = new oco.Entry('colornameA', [oco.ColorValue.fromColorValue('#FFFFFF')]);
+    var colorB = new oco.Entry('colornameB', [oco.ColorValue.fromColorValue('#000000')]);
+
+    root.set('colornameA', colorA);
+    expect(root.get('colornameA').hexcolor()).to.equal('#FFFFFF');
+    root.set('colornameA', colorB);
+    expect(root.get('colornameA').hexcolor()).to.equal('#000000');
+  });
+  it("should overwrite existing entry with different type", () => {
+    var root = new oco.Entry();
+    var colorA = new oco.Entry('entrynameA', [oco.ColorValue.fromColorValue('#FFFFFF')]);
+    var referenceA = new oco.Reference('entrynameB', '=xxx');
+
+    root.set('entrynameA', colorA);
+    expect(root.get('entrynameA').hexcolor()).to.equal('#FFFFFF');
+    root.set('entrynameA', referenceA);
+    expect(root.get('entrynameA').type).to.equal('Reference');
+  });
 });

--- a/test/manual_creation_test.js
+++ b/test/manual_creation_test.js
@@ -6,7 +6,7 @@ var oco = require('../lib/index.js');
 describe('Manually creating OCO objects', () => {
   it("should create a root palette", () => {
     var root = new oco.Entry();
-    expect(root.parent).to.be.null;
+    expect(root.parent).to.equal(null);
     expect(root.name).to.equal('Root');
   });
   it("is possible to create more than one entry with sharing one dotpath", () => {

--- a/test/parser_test.js
+++ b/test/parser_test.js
@@ -94,7 +94,7 @@ color:
   #ff0022
 `;
     var tree = parser.parse(test);
-    expect(tree.parent).to.be.null;
+    expect(tree.parent).to.equal(null);
     expect(tree.name).to.equal('root');
     expect(tree.get('color').type).to.equal('Color');
     expect(tree.get('color').hexcolor()).to.equal('#FF0022');
@@ -143,7 +143,7 @@ Root:
   800: #1565C0`;
     var tree = parser.parse(test);
     expect(tree.get('Root').type).to.equal('Palette');
-    expect(tree.get('Root').parent).to.not.be.null;
+    expect(tree.get('Root').parent).to.not.equal(null);
   });
 
 

--- a/test/parser_test.js
+++ b/test/parser_test.js
@@ -94,7 +94,7 @@ color:
   #ff0022
 `;
     var tree = parser.parse(test);
-    expect(tree.type).to.equal('Root');
+    expect(tree.parent).to.be.null;
     expect(tree.name).to.equal('root');
     expect(tree.get('color').type).to.equal('Color');
     expect(tree.get('color').hexcolor()).to.equal('#FF0022');
@@ -142,7 +142,8 @@ Root:
   50: #E3F2FD
   800: #1565C0`;
     var tree = parser.parse(test);
-    expect(tree.get('Root').type).to.equal('Entry');
+    expect(tree.get('Root').type).to.equal('Palette');
+    expect(tree.get('Root').parent).to.not.be.null;
   });
 
 

--- a/test/parser_test.js
+++ b/test/parser_test.js
@@ -66,7 +66,7 @@ describe("Parser", () => {
     var test = "color: rgb(10,20,30)\n";
     var tree = parser.parse(test);
     expect(tree.name).to.equal('root');
-    expect(tree.get('color').get('rgb').value.toString('rgb')).to.equal('rgb(10, 20, 30)');
+    expect(tree.get('color').get('rgb').value).to.equal('rgb(10,20,30)');
   });
 
   it("should parse a single color as an special value", () => {

--- a/test/renderer_test.js
+++ b/test/renderer_test.js
@@ -13,7 +13,7 @@ describe('Renderer', () => {
     tree.addChild(color);
     var result = oco.render(tree);
     var expected = `bright yellow:
-  #ffffee
+  #ffe
   key/key: Value
 `;
     expect(result).to.equal(expected);
@@ -27,7 +27,7 @@ describe('Renderer', () => {
     tree.addChild(color);
     tree.addChild(ref);
     var result = oco.render(tree);
-    var expected = `bright yellow: #ffffee
+    var expected = `bright yellow: #ffe
 almost yellow: =bright yellow
 `;
     expect(result).to.equal(expected);
@@ -42,7 +42,7 @@ almost yellow: =bright yellow
     tree.addChild(palette);
     var result = oco.render(tree);
     var expected = `yellows:
-  bright yellow: #ffffee
+  bright yellow: #ffe
 `;
     expect(result).to.equal(expected);
   });


### PR DESCRIPTION
(opening this pull request, to have a place for discussion with @halfbyte and @theflow)

my goal is to establish the following model of an oco file as good as possible in the core of the library, so all parts of oct are based on a common well formed understanding of oco.

- a palette can contain entries.
- entries are of one the following types: palette, color, reference
- every entry, independent of its type has a name.
- every entry but root belong to a palette, its called parent (either the file or another child palette, defined by an entry type)
- the name an the relation to the parent are used to form the path (dotpath)
- every oco file is a palette without a parent

do you agree on the model?

as a first step i renamed 'Entry' to 'Palette' to be more meaningful.
root is defined by the fact that entry.parent is null.

this change causes some refactoring in renderer and companion app (basically just search and replace type checks).

continue?